### PR TITLE
Add option to generated colourized graphs

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -291,34 +291,62 @@ Target "GenerateSources" DoNothing
 Target "WordCountSvg" (fun _ ->
     Shell.Exec(
 #if MONO
-            "mono",
+            "dotnet",
             ""+
 #else
             Environment.GetEnvironmentVariable("ComSpec"),
-            "/c "+
+            "/c dotnet "+
 #endif
-            ("samples" @@ "WordCount" @@ "bin" @@ "Release" @@ "WordCount.exe") +
-            " graph | dot -Tsvg -o " + "samples/WordCount/obj/WordCount.svg")
+            ("samples" @@ "WordCount" @@ "bin" @@ "Release" @@ "netcoreapp2.1" @@ "WordCount.dll") +
+            " graph | dot -Tsvg -o samples/WordCount/obj/WordCount.svg")
+    |> ignore
+)
+
+Target "WordCountColourSvg" (fun _ ->
+    Shell.Exec(
+#if MONO
+            "dotnet",
+            ""+
+#else
+            Environment.GetEnvironmentVariable("ComSpec"),
+            "/c dotnet "+
+#endif
+            ("samples" @@ "WordCount" @@ "bin" @@ "Release" @@ "netcoreapp2.1" @@ "WordCount.dll") +
+            " colour-graph | dot -Tsvg -o " + "samples/WordCount/obj/WordCount_colourized.svg")
+    |> ignore
+)
+
+Target "WordCountCustomColourSvg" (fun _ ->
+    Shell.Exec(
+#if MONO
+            "dotnet",
+            ""+
+#else
+            Environment.GetEnvironmentVariable("ComSpec"),
+            "/c dotnet "+
+#endif
+            ("samples" @@ "WordCount" @@ "bin" @@ "Release" @@ "netcoreapp2.1" @@ "WordCount.dll") +
+            " custom-colour-graph | dot -Tsvg -o " + "samples/WordCount/obj/WordCount_custom_colourized.svg")
     |> ignore
 )
 
 Target "GuaranteedSvg" (fun _ ->
     Shell.Exec(
 #if MONO
-            "mono",
+            "dotnet",
             ""+
 #else
             Environment.GetEnvironmentVariable("ComSpec"),
-            "/c "+
+            "/c dotnet "+
 #endif
-            ("samples" @@ "Guaranteed" @@ "bin" @@ "Release" @@ "Guaranteed.exe") +
+            ("samples" @@ "Guaranteed" @@ "bin" @@ "Release" @@ "netcoreapp2.1" @@ "Guaranteed.dll") +
             " graph | dot -Tsvg -o " + "samples/Guaranteed/obj/Guaranteed.svg")
     |> ignore
 )
 
 Target "ExportGraphs" DoNothing
 "ExportGraphs"
-    <== ["Build";"WordCountSvg";"GuaranteedSvg"]
+    <== ["Build"; "WordCountSvg"; "WordCountColourSvg"; "WordCountCustomColourSvg"; "GuaranteedSvg"]
 
 Target "All" DoNothing
 "All"

--- a/docs/content/wordcount.fsx
+++ b/docs/content/wordcount.fsx
@@ -17,14 +17,14 @@ FsShelter uses F# discriminated unions to statically type streams:
 type Schema = 
     | Sentence of string
     | Word of string
-    | WordCount of string*int64
+    | WordCount of string * int64
 
 (**
 Defining unreliable spouts
 --------------------
 
 FsShelter spouts can be implemented as "reliable" or "unreliable". 
-Either implementation is a single function, returning async Option, where None indicates there's nothing to emit from this spout at this moment:
+Either implementation is a single function, returning an `async option`, where `None` indicates there's nothing to emit from this spout at this moment:
 
 *)
 
@@ -35,7 +35,7 @@ let sentences source = source() |> Sentence |> Some
 Defining bolts
 --------------------
 
-A couple of examples of a FsShelter bolts that read a tuple and emit another one:
+A couple of examples of FsShelter bolts that read a tuple and emit another one:
 
 *)
 
@@ -92,7 +92,7 @@ let increment =
 Using F# DSL to define a topology
 --------------------
 
-A typical (event-streaming) Storm topology is a graph of spouts and bolts connected via streams that can be defined via `topology` computation expression:
+A typical (event-streaming) Storm topology is a graph of spouts and bolts connected via streams that can be defined via a `topology` computation expression:
 *)
 
 open FsShelter.DSL
@@ -102,18 +102,20 @@ open FsShelter.DSL
 let sampleTopology = 
     topology "WordCount" { 
         let sentencesSpout = 
-            sentences 
-            |> Spout.runUnreliable (fun log cfg -> source)        // make arguments: ignoring Storm logging and cfg, passing our source function
-                                   ignore
+            sentences
+            |> Spout.runUnreliable (fun log cfg -> source)  // make arguments: ignoring Storm logging and cfg, passing our source function
+                                   ignore                   // no deactivation
+            |> withParallelism 4
+        
         let splitBolt = 
             splitIntoWords
             |> Bolt.run (fun log cfg tuple emit -> (tuple, emit)) // make arguments: pass incoming tuple and emit function
-            |> withParallelism 2
+            |> withParallelism 4
         
         let countBolt = 
             countWords
             |> Bolt.run (fun log cfg tuple emit -> (tuple, increment, emit))
-            |> withParallelism 2
+            |> withParallelism 4
         
         let logBolt = 
             logResult
@@ -129,14 +131,14 @@ let sampleTopology =
 
 (**
 Here we define the graph by declaring the components and connecting them with arrows. 
-The lambda arguments for the "run" methods privde the opportunity to carry out construction of the arguments that will be passed into the component functions, where:
+The lambda arguments for the "run" methods provide the opportunity to carry out construction of the arguments that will be passed into the component functions, where:
 
 * `log` is the Storm log factory
 * `cfg` is the runtime configuration passed in from Storm 
 * `tuple` is the instance of the schema DU coming in
 * `emit` is the function to emit another tuple
 
-`log` and `cfg` are fixed once (curried) and as demonstrated in the logBolt's mkArgs lambda, one time-initialization can be carried out by inserting arbitrary code before `tuple` and `emit` arguments.
+`log` and `cfg` are fixed once (curried) and as demonstrated in the `logBolt`'s `mkArgs` lambda, one time-initialization can be carried out by inserting arbitrary code before `tuple` and `emit` arguments.
 This initialization will not be triggered unless the task execution is actually requested by Storm for this specific instance of the process.
 
 
@@ -158,13 +160,13 @@ Then the execution will be handed over to one of the corresponding "dispatchers"
 Keep in mind that:
 
 * STDIN/STDOUT are reserved for communications with Storm and any IO the component is going to do has to go through some other channel (no console logging!).
-* out of the box Storm only supports JSON multilang, for faster IO consider [ProtoShell](https://github.com/prolucid/protoshell). The serilizer JAR can be bundled along with the submitted topology or deployed in Storm's classpath beforehand.
+* out of the box Storm only supports JSON multilang. For faster IO, consider [ProtoShell](https://github.com/prolucid/protoshell). The serilizer JAR can be bundled along with the submitted topology or deployed in Storm's classpath beforehand.
 
 
 Exporting the topology graph
 --------------
 
-FsShelter includes a completely customizable GraphViz (dot) export functionality, here's what the word count topology looks like with default renderers:
+FsShelter includes a completely customizable GraphViz (dot) export functionality. Here's what the word count topology looks like with default renderers:
 
 ![SVG](svg/WordCount.svg "WordCount (SVG)")
 
@@ -175,11 +177,27 @@ This was achived by a simple export to console:
 sampleTopology |> DotGraph.writeToConsole
 
 (**
-Followed by further conversion into a desired format, piping the markup into GrapViz:
+Followed by further conversion into a desired format, piping the markup into GraphViz:
 
 ```bash
 dotnet samples/WordCount/bin/Release/netcoreapp2.1/WordCount.dll graph | dot -Tsvg -o build/WordCount.svg
 ```
+
+It is also possible to generate graphs with colour-coded streams:
 *)
 
+sampleTopology |> DotGraph.writeColourizedToConsole
 
+(**
+![SVG](svg/WordCount_colourized.svg "Colourized WordCount (SVG)")
+
+Alternatively, you can provide your own X11 colour scheme:
+*)
+
+let customColours = [| "purple"; "dodgerblue"; "springgreen"; "olivedrab"; "orange"; "orangered"; "maroon"; "black" |]
+sampleTopology
+|> DotGraph.exportToDot (DotGraph.writeHeader, DotGraph.writeFooter, DotGraph.writeSpout, DotGraph.writeBolt, DotGraph.writeColourfulStream <| DotGraph.getColour customColours) System.Console.Out
+
+(**
+![SVG](svg/WordCount_custom_colourized.svg "Custom Colourized WordCount (SVG)")
+*)

--- a/docs/files/svg/WordCount_colourized.svg
+++ b/docs/files/svg/WordCount_colourized.svg
@@ -23,9 +23,9 @@
 </g>
 <!-- sentencesSpout&#45;&gt;splitBolt -->
 <g id="edge2" class="edge"><title>sentencesSpout&#45;&gt;splitBolt</title>
-<path fill="none" stroke="black" d="M147.284,-26.8701C172.566,-26.8701 200.444,-26.8701 223.907,-26.8701"/>
-<polygon fill="black" stroke="black" points="224.011,-30.3702 234.011,-26.8701 224.011,-23.3702 224.011,-30.3702"/>
-<text text-anchor="middle" x="190.578" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00">Sentence</text>
+<path fill="none" stroke="dimgray" d="M147.284,-26.8701C172.566,-26.8701 200.444,-26.8701 223.907,-26.8701"/>
+<polygon fill="dimgray" stroke="dimgray" points="224.011,-30.3702 234.011,-26.8701 224.011,-23.3702 224.011,-30.3702"/>
+<text text-anchor="start" x="165.078" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00" fill="dimgray">Sentence</text>
 </g>
 <!-- countBolt -->
 <g id="node2" class="node"><title>countBolt</title>
@@ -41,15 +41,15 @@
 </g>
 <!-- countBolt&#45;&gt;logBolt -->
 <g id="edge1" class="edge"><title>countBolt&#45;&gt;logBolt</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M493.954,-26.8701C522.629,-26.8701 558.596,-26.8701 587.276,-26.8701"/>
-<polygon fill="black" stroke="black" points="587.486,-30.3702 597.486,-26.8701 587.486,-23.3702 587.486,-30.3702"/>
-<text text-anchor="middle" x="545.583" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00">WordCount</text>
+<path fill="none" stroke="red" stroke-dasharray="5,2" d="M493.954,-26.8701C522.629,-26.8701 558.596,-26.8701 587.276,-26.8701"/>
+<polygon fill="red" stroke="red" points="587.486,-30.3702 597.486,-26.8701 587.486,-23.3702 587.486,-30.3702"/>
+<text text-anchor="start" x="511.583" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00" fill="red">WordCount</text>
 </g>
 <!-- splitBolt&#45;&gt;countBolt -->
 <g id="edge3" class="edge"><title>splitBolt&#45;&gt;countBolt</title>
 <path fill="none" stroke="black" d="M323.241,-26.8701C341.522,-26.8701 363.071,-26.8701 382.779,-26.8701"/>
 <polygon fill="black" stroke="black" points="382.891,-30.3702 392.891,-26.8701 382.891,-23.3702 382.891,-30.3702"/>
-<text text-anchor="middle" x="358.174" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00">Word</text>
+<text text-anchor="start" x="341.174" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00">Word</text>
 </g>
 </g>
 </svg>

--- a/docs/files/svg/WordCount_custom_colourized.svg
+++ b/docs/files/svg/WordCount_custom_colourized.svg
@@ -23,9 +23,9 @@
 </g>
 <!-- sentencesSpout&#45;&gt;splitBolt -->
 <g id="edge2" class="edge"><title>sentencesSpout&#45;&gt;splitBolt</title>
-<path fill="none" stroke="black" d="M147.284,-26.8701C172.566,-26.8701 200.444,-26.8701 223.907,-26.8701"/>
-<polygon fill="black" stroke="black" points="224.011,-30.3702 234.011,-26.8701 224.011,-23.3702 224.011,-30.3702"/>
-<text text-anchor="middle" x="190.578" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00">Sentence</text>
+<path fill="none" stroke="springgreen" d="M147.284,-26.8701C172.566,-26.8701 200.444,-26.8701 223.907,-26.8701"/>
+<polygon fill="springgreen" stroke="springgreen" points="224.011,-30.3702 234.011,-26.8701 224.011,-23.3702 224.011,-30.3702"/>
+<text text-anchor="start" x="165.078" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00" fill="springgreen">Sentence</text>
 </g>
 <!-- countBolt -->
 <g id="node2" class="node"><title>countBolt</title>
@@ -41,15 +41,15 @@
 </g>
 <!-- countBolt&#45;&gt;logBolt -->
 <g id="edge1" class="edge"><title>countBolt&#45;&gt;logBolt</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M493.954,-26.8701C522.629,-26.8701 558.596,-26.8701 587.276,-26.8701"/>
-<polygon fill="black" stroke="black" points="587.486,-30.3702 597.486,-26.8701 587.486,-23.3702 587.486,-30.3702"/>
-<text text-anchor="middle" x="545.583" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00">WordCount</text>
+<path fill="none" stroke="maroon" stroke-dasharray="5,2" d="M493.954,-26.8701C522.629,-26.8701 558.596,-26.8701 587.276,-26.8701"/>
+<polygon fill="maroon" stroke="maroon" points="587.486,-30.3702 597.486,-26.8701 587.486,-23.3702 587.486,-30.3702"/>
+<text text-anchor="start" x="511.583" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00" fill="maroon">WordCount</text>
 </g>
 <!-- splitBolt&#45;&gt;countBolt -->
 <g id="edge3" class="edge"><title>splitBolt&#45;&gt;countBolt</title>
-<path fill="none" stroke="black" d="M323.241,-26.8701C341.522,-26.8701 363.071,-26.8701 382.779,-26.8701"/>
-<polygon fill="black" stroke="black" points="382.891,-30.3702 392.891,-26.8701 382.891,-23.3702 382.891,-30.3702"/>
-<text text-anchor="middle" x="358.174" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00">Word</text>
+<path fill="none" stroke="dodgerblue" d="M323.241,-26.8701C341.522,-26.8701 363.071,-26.8701 382.779,-26.8701"/>
+<polygon fill="dodgerblue" stroke="dodgerblue" points="382.891,-30.3702 392.891,-26.8701 382.891,-23.3702 382.891,-30.3702"/>
+<text text-anchor="start" x="341.174" y="-30.6701" font-family="Times New Roman,serif" font-size="14.00" fill="dodgerblue">Word</text>
 </g>
 </g>
 </svg>

--- a/samples/Guaranteed/Program.fs
+++ b/samples/Guaranteed/Program.fs
@@ -28,6 +28,13 @@ let main argv =
     | ["graph"] ->
         topology
         |> DotGraph.writeToConsole
+    | ["colour-graph"] ->
+        topology
+        |> DotGraph.writeColourizedToConsole
+    | ["custom-colour-graph"] ->
+        let customColours = [| "purple"; "dodgerblue"; "springgreen"; "olivedrab"; "orange"; "orangered"; "maroon"; "black" |]
+        topology
+        |> DotGraph.exportToDot (DotGraph.writeHeader, DotGraph.writeFooter, DotGraph.writeSpout, DotGraph.writeBolt, DotGraph.writeColourfulStream <| DotGraph.getColour customColours) System.Console.Out
     | ["self-host"] ->
         let stop = 
             topology

--- a/samples/WordCount/Program.fs
+++ b/samples/WordCount/Program.fs
@@ -26,6 +26,13 @@ let main argv =
     | ["graph"] ->
         topology
         |> DotGraph.writeToConsole
+    | ["colour-graph"] ->
+        topology
+        |> DotGraph.writeColourizedToConsole
+    | ["custom-colour-graph"] ->
+        let customColours = [| "purple"; "dodgerblue"; "springgreen"; "olivedrab"; "orange"; "orangered"; "maroon"; "black" |]
+        topology
+        |> DotGraph.exportToDot (DotGraph.writeHeader, DotGraph.writeFooter, DotGraph.writeSpout, DotGraph.writeBolt, DotGraph.writeColourfulStream <| DotGraph.getColour customColours) System.Console.Out
     | _ -> 
         topology
         |> Task.ofTopology

--- a/src/FsShelter/DotGraph.fs
+++ b/src/FsShelter/DotGraph.fs
@@ -38,6 +38,42 @@ let writeStream writer ((_,sid),_) (st:Stream<_>) =
         | false -> "dotted"
     fprintfn writer "\t%s -> %s [label=%s; style=%s]" st.Src st.Dst sid (style st.Anchoring)
 
+/// X11 colours
+let streamColours = [| "crimson"; "palevioletred"; "mediumvioletred"; "magenta"; "purple"; "slateblue"; "blue"; "royalblue"; "dodgerblue"; "darkturquoise"; "darkslategray"; "teal"; "springgreen"; "seagreen"; "lime"; "forestgreen"; "olivedrab"; "goldenrod"; "darkgoldenrod"; "orange"; "tan"; "saddlebrown"; "orangered"; "lightcoral"; "indianred"; "red"; "maroon"; "dimgray"; "black" |]
+
+/// lookup a colour based on a stream id
+let getColour (colours:string []) =
+    // FNV-1 Hash function (32-bit) - see https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    let fnv1Hash32 (s:string) =
+        let fnvPrime32 = 16777619u
+        let fnvOffsetBasis32 = 2166136261u
+        let xor (hash:uint32) (b:uint32) =
+            let hashLower8Bits = 0x000000FFu &&& hash
+            let hashUpper24Bits = 0xFFFFFF00u &&& hash
+            let lowerXor = hashLower8Bits ^^^ b
+            hashUpper24Bits + lowerXor
+
+        s.ToCharArray()
+        |> Array.fold (fun hash c ->
+            let data = uint32 c
+            let h = hash * fnvPrime32
+            xor h data) fnvOffsetBasis32
+
+    fun (s:string) ->
+        colours.[int ((fnv1Hash32 s) % (uint32 <| colours.Length))]
+
+/// colourized edge statement for a stream
+let writeColourfulStream getColour writer ((_, sid), _) (st:Stream<_>) =
+    let style = function
+        | true -> "solid"
+        | false -> "dashed"
+    let colour = getColour sid
+    fprintfn writer "\t%s -> %s [label=<<font color=\"%s\">%s</font>>; style=%s; color=%s]" st.Src st.Dst colour sid (style st.Anchoring) colour
+    
 /// put together default implementations to write to STDOUT
 let writeToConsole t = 
     t |> exportToDot (writeHeader,writeFooter,writeSpout,writeBolt,writeStream) System.Console.Out
+
+/// put together default implementations with colour to write to STDOUT
+let writeColourizedToConsole t = 
+    t |> exportToDot (writeHeader,writeFooter,writeSpout,writeBolt,writeColourfulStream <| getColour streamColours) System.Console.Out


### PR DESCRIPTION
* Added the following functions to `DotGraph`:
    * `getColour` - lookup a colour based on a stream id
    * `writeColourfulStream` - colourized edge statement for a stream
    * `writeColourizedToConsole` - like `writeToConsole`, but with a default colour scheme

* Updated WordCount documentation to demonstrate different ways to generate colourized graphs
* Added and updated SVG build tasks to use `dotnet`